### PR TITLE
(FE) [FEAT] 커스텀 오버레이 기능 구현

### DIFF
--- a/client/src/apis/place.api.ts
+++ b/client/src/apis/place.api.ts
@@ -13,7 +13,7 @@ export const fetchPlaces = async (params: PlaceParams) => {
     }
   });
 
-  const url = `/api/facilities?${query.toString()}`;
+  const url = `/facilities?${query.toString()}`;
 
   try {
     const response = await httpClient.get(url);

--- a/client/src/components/search/SearchBox.tsx
+++ b/client/src/components/search/SearchBox.tsx
@@ -21,6 +21,15 @@ function SearchBox() {
         bplcnm: searchInputPlace,
       });
 
+      // 결과가 배열인지 확인
+      if (!Array.isArray(results)) {
+        console.error(
+          '배열을 기대했으나 다른 데이터 형식이 반환되었습니다:',
+          results
+        );
+        return;
+      }
+
       // 입력값을 포함하는 데이터만 필터링
       const filteredResults = results.filter((place: PlaceData) => {
         const x = Number(place.x);

--- a/client/src/components/search/map/SearchMapOverlay.tsx
+++ b/client/src/components/search/map/SearchMapOverlay.tsx
@@ -1,6 +1,10 @@
 import { FaX } from 'react-icons/fa6';
 import styled from 'styled-components';
 import { PlaceData } from '../../../types/place.type';
+import {
+  MdDoNotDisturbOnTotalSilence,
+  MdExpandCircleDown,
+} from 'react-icons/md';
 
 interface Props {
   onClick: (markerId: number) => void;
@@ -8,11 +12,37 @@ interface Props {
 }
 
 function SearchMapOverlay({ onClick, place }: Props) {
+  const handleCopyTelClick = (tel: string) => {
+    navigator.clipboard
+      .writeText(tel)
+      .then(() => {
+        alert(`${place.bplcnm}의 전화번호가 복사되었습니다: ${tel}`);
+      })
+      .catch((err) => {
+        console.error('전화번호 복사:', err);
+      });
+  };
+
   return (
     <SearchMapOverlayStyle>
       <div className="overlayWrap">
         <div className="info">
-          <div className="title">{place.bplcnm}</div>
+          <div className="title">
+            <div>{place.bplcnm}</div>
+            <div className="state">
+              {place.dtlstatenm === '정상' ? (
+                <div className="opened">
+                  <MdExpandCircleDown className="stateIcon" />
+                  {place.dtlstatenm}
+                </div>
+              ) : (
+                <div className="closed">
+                  <MdDoNotDisturbOnTotalSilence className="stateIcon" />
+                  {place.dtlstatenm}
+                </div>
+              )}
+            </div>
+          </div>
           <FaX className="closebttn" onClick={() => onClick(place.id)} />
         </div>
         <div className="address">
@@ -20,22 +50,31 @@ function SearchMapOverlay({ onClick, place }: Props) {
             {place.rdnwhladdr ? (
               place.rdnwhladdr
             ) : (
-              <div className="notPrepared">준비되지 않은 정보입니다</div>
+              <div className="notPrepared">
+                <MdDoNotDisturbOnTotalSilence className="notIcon" />
+                <p>준비되지 않은 정보입니다</p>
+              </div>
             )}
           </div>
           <div className="sitewhladdr">
             {place.sitewhladdr ? (
               place.sitewhladdr
             ) : (
-              <div className="notPrepared">준비되지 않은 정보입니다</div>
+              <div className="notPrepared">
+                <MdDoNotDisturbOnTotalSilence className="notIcon" />
+                <p>준비되지 않은 정보입니다</p>
+              </div>
             )}
           </div>
         </div>
-        <div className="tel">
+        <div className="tel" onClick={() => handleCopyTelClick(place.sitetel)}>
           {place.sitetel ? (
             place.sitetel
           ) : (
-            <div className="notPrepared">준비되지 않은 정보입니다</div>
+            <div className="notPrepared">
+              <MdDoNotDisturbOnTotalSilence className="notIcon" />
+              <p>준비되지 않은 정보입니다</p>
+            </div>
           )}
         </div>
       </div>
@@ -67,9 +106,29 @@ const SearchMapOverlayStyle = styled.div`
       align-items: center;
       gap: 10px;
       .title {
+        display: flex;
         font-size: 14px;
         font-weight: bold;
-        padding-top: 5px;
+        border-bottom: solid #d9d9d9;
+        align-items: end;
+        gap: 5px;
+        .state {
+          font-size: 8px;
+          .opened {
+            display: flex;
+            align-items: center;
+            color: #5ba95b;
+          }
+          .closed {
+            display: flex;
+            align-items: center;
+            color: #e44c4c;
+          }
+          .stateIcon {
+            font-size: 12px;
+            padding-bottom: 1px;
+          }
+        }
       }
       .closebttn {
         cursor: pointer;
@@ -97,11 +156,17 @@ const SearchMapOverlayStyle = styled.div`
       padding: 5px;
       padding-left: 10px;
       font-size: 10px;
+      cursor: pointer;
     }
 
     .notPrepared {
+      display: flex;
+      align-items: center;
       font-size: 6px;
       color: #a0a0a0;
+      .notIcon {
+        font-size: 9px;
+      }
     }
   }
   .overlayWrap:after {

--- a/client/src/components/search/map/SearchMapOverlay.tsx
+++ b/client/src/components/search/map/SearchMapOverlay.tsx
@@ -1,0 +1,122 @@
+import { FaX } from 'react-icons/fa6';
+import styled from 'styled-components';
+import { PlaceData } from '../../../types/place.type';
+
+interface Props {
+  onClick: (markerId: number) => void;
+  place: PlaceData;
+}
+
+function SearchMapOverlay({ onClick, place }: Props) {
+  return (
+    <SearchMapOverlayStyle>
+      <div className="overlayWrap">
+        <div className="info">
+          <div className="title">{place.bplcnm}</div>
+          <FaX className="closebttn" onClick={() => onClick(place.id)} />
+        </div>
+        <div className="address">
+          <div className="rdnwhladdr">
+            {place.rdnwhladdr ? (
+              place.rdnwhladdr
+            ) : (
+              <div className="notPrepared">준비되지 않은 정보입니다</div>
+            )}
+          </div>
+          <div className="sitewhladdr">
+            {place.sitewhladdr ? (
+              place.sitewhladdr
+            ) : (
+              <div className="notPrepared">준비되지 않은 정보입니다</div>
+            )}
+          </div>
+        </div>
+        <div className="tel">
+          {place.sitetel ? (
+            place.sitetel
+          ) : (
+            <div className="notPrepared">준비되지 않은 정보입니다</div>
+          )}
+        </div>
+      </div>
+    </SearchMapOverlayStyle>
+  );
+}
+
+const SearchMapOverlayStyle = styled.div`
+  position: absolute;
+  bottom: 80px;
+  left: -100px;
+  cursor: default;
+
+  .overlayWrap {
+    border-radius: 16px;
+    background-color: white;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    position: relative;
+    border-radius: 16px;
+    width: 200px;
+    white-space: normal;
+
+    .info {
+      display: flex;
+      justify-content: space-between;
+      padding: 10px;
+      border-top-left-radius: 16px;
+      border-top-right-radius: 16px;
+      align-items: center;
+      gap: 10px;
+      .title {
+        font-size: 14px;
+        font-weight: bold;
+        padding-top: 5px;
+      }
+      .closebttn {
+        cursor: pointer;
+        font-size: 12px;
+        color: #d9d9d9;
+      }
+      .closebttn:hover {
+        color: black;
+      }
+    }
+
+    .address {
+      padding: 0 10px 5px;
+      font-size: 7px;
+      .sitewhladdr {
+        font-size: 6px;
+        color: #464646;
+      }
+    }
+
+    .tel {
+      background-color: #d9d9d9;
+      border-bottom-left-radius: 16px;
+      border-bottom-right-radius: 16px;
+      padding: 5px;
+      padding-left: 10px;
+      font-size: 10px;
+    }
+
+    .notPrepared {
+      font-size: 6px;
+      color: #a0a0a0;
+    }
+  }
+  .overlayWrap:after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    width: 0;
+    height: 0;
+    border: 21px solid transparent;
+    border-top-color: #d9d9d9;
+    border-bottom: 0;
+    margin-left: -21px;
+    margin-bottom: -15px;
+  }
+`;
+
+export default SearchMapOverlay;

--- a/client/src/store/slices/placeSlice.ts
+++ b/client/src/store/slices/placeSlice.ts
@@ -14,7 +14,6 @@ const placeSlice = createSlice({
   reducers: {
     setSearchInputPlace(state, action: PayloadAction<string>) {
       state.searchInputPlace = action.payload;
-      state.searchPlaceResults = [];
     },
     setResults(state, action: PayloadAction<PlaceData[]>) {
       state.searchPlaceResults = action.payload;

--- a/client/src/types/place.type.ts
+++ b/client/src/types/place.type.ts
@@ -7,6 +7,7 @@ export interface PlaceData {
   sitetel: string; // 전화번호
   x: number | null; // WTM 좌표(위도)
   y: number | null; // WTM 좌표(경도)
+  dtlstatenm: string; // 영업 상태(정상 | 폐업)
 }
 
 export interface PlaceState {

--- a/server/app.js
+++ b/server/app.js
@@ -8,7 +8,6 @@ const cors = require("cors");
 app.use(cors({ origin: "http://localhost:5000", credentials: true }));
 
 app.use(express.json());
-app.use(express.json());
 
 // swagger 연동
 const { swaggerUi, specs } = require("./swagger/swagger")
@@ -20,7 +19,7 @@ app.get('/search', (req, res) => {
 });
 
 // 지도에 위치 표시
-app.get('/api/facilities', (req, res) => {
+app.get('/facilities', (req, res) => {
     const { type, keyword } = req.query;
     let query = 'SELECT * FROM medical_facilities WHERE 1=1';
     const values = [];


### PR DESCRIPTION
<!--
  제목은 `제목 : (FE, BE) [(키워드)] (작업 내용)` 로 작성해 주세요
  키워드 예시: FEAT, FIX, STYLE, CHORE ... 등
-->

## 설명
- 지도 위 마커 클릭 시 커스텀한 오버레이가 나타남

### 관련 Issue

<!--
  (Optional)
  관련 Issue number를 작성해주세요
-->
#26 #29 #39 

### 스크린샷 

<!--
  (Optional)
  UI가 변경되었다면 사진이나 Gif를 추가해 주세요.
-->
![image](https://github.com/user-attachments/assets/b1a092b7-a371-4b37-af85-666ada037947)
![image](https://github.com/user-attachments/assets/f1422c72-0ed8-4b78-92c7-526185d461fe)


### 작업 내용

<!-- PR 본문을 입력하세요. -->
- 마커 클릭 시 위로 말풍선 형태의 오버레이가 열림.
- 닫기 버튼 또는 마커 재클릭 시 오버레이 닫힘.
- 전화번호 누르면 복사됨.

- 서버 측의 검색 api 주소가 스웨거 UI와 겹쳐 수정함.
