### PR TITLE
(FE) [FEAT] 카테고리 페이지 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import { PetMediThemeProvider } from './style/themeContext';
 import MyProfile from './pages/MyProfile';
 import LoginProtect from './components/common/LoginProtect';
 import CreatePost from './pages/CreatePost';
+import Categories from './pages/Category';
 
 const routeList = [
   {
@@ -26,6 +27,10 @@ const routeList = [
   {
     path: '/login',
     element: <Login />,
+  },
+  {
+    path: '/category',
+    element: <Categories />,
   },
   {
     path: '/posts',

--- a/client/src/Category/Category.tsx
+++ b/client/src/Category/Category.tsx
@@ -1,20 +1,15 @@
 import { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { useParams } from 'react-router-dom';
+// import { useParams } from 'react-router-dom';
 import axios from 'axios';
 
 export default function Category() {
   const [categorypost, setCategoryPost] = useState({
     category: [],
   });
-  const { id } = useParams();
+  // const { id } = useParams();
   const getPost = async () => {
-    const res = await axios.get(
-      {
-        /*URL */
-      },
-      id
-    );
+    const res = await axios.get('http://localhost:8080/category');
     setCategoryPost(res.data);
   };
   useEffect(() => {

--- a/client/src/apis/category.api.ts
+++ b/client/src/apis/category.api.ts
@@ -2,6 +2,6 @@ import axios from 'axios';
 import { Category } from '../types/type';
 
 export const fetchCategory = async () => {
-  const response = await axios.get<Category[]>('/category');
+  const response = await axios.get<Category[]>('localhost:8080/category');
   return response.data;
 };

--- a/client/src/components/common/Menu.tsx
+++ b/client/src/components/common/Menu.tsx
@@ -17,7 +17,7 @@ function Menu() {
     navigate('/search');
   };
   const handlePostsClick = () => {
-    navigate('/posts');
+    navigate('/category');
   };
   const handleMyProfileClick = () => {
     navigate('/myprofile');

--- a/client/src/pages/Category.tsx
+++ b/client/src/pages/Category.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Category } from '../types/type';
+import { useNavigate } from 'react-router-dom';
+
+function Categories() {
+  const [category, setCategory] = useState<Category[]>();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await axios.get('http://localhost:8080/category');
+      setCategory(response.data);
+    };
+    fetchData();
+  }, []);
+
+  const handleCategoryClick = (id) => {
+    navigate(`/posts?categoryId=${id}`); // 해당 카테고리 ID로 URL 변경
+  };
+
+  return (
+    <>
+      {category?.map((item) => (
+        <button
+          key={item.category_id}
+          onClick={() => handleCategoryClick(item.category_id)}
+        >
+          {item.category_name}
+        </button>
+      ))}
+    </>
+  );
+}
+
+export default Categories;

--- a/client/src/pages/Posts.tsx
+++ b/client/src/pages/Posts.tsx
@@ -1,26 +1,43 @@
 import styled from 'styled-components';
-import Programming from '../components/common/Programming';
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import Post from '../components/PostList';
+import { useLocation } from 'react-router-dom';
 
 function Posts() {
   const [posts, setPosts] = useState([]);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [postsPerPage, setPostsPerPage] = useState(10);
+  const location = useLocation();
 
+  // 'categoryId' 쿼리 파라미터에서 가져옴 (오타 수정)
+  const categoryId = new URLSearchParams(location.search).get('categoryId');
+
+  // 카테고리 ID에 맞는 포스트 데이터를 가져오는 useEffect
   useEffect(() => {
-    const fetchData = async () => {
-      const response = await axios.get('http://localhost:8080/api/posts');
-      setPosts(response.data);
+    const fetchPostsByCategory = async () => {
+      if (categoryId) {
+        try {
+          const response = await axios.get(
+            `http://localhost:8080/category?category=${categoryId}`
+          );
+          setPosts(response.data.posts); // 포스트 데이터 설정
+        } catch (error) {
+          console.error('Error fetching posts:', error);
+        }
+      }
     };
-    fetchData();
-  }, []);
+    fetchPostsByCategory();
+  }, []); // categoryId가 변경될 때마다 실행
 
   return (
-    <PostsStyle>
-      <Post post={posts} />
-    </PostsStyle>
+    <>
+      <PostsStyle>
+        {posts.length > 0 ? (
+          <Post post={posts} /> // 포스트 렌더링
+        ) : (
+          <p>No posts available for this category.</p> // 포스트가 없을 때 메시지
+        )}
+      </PostsStyle>
+    </>
   );
 }
 

--- a/client/src/types/type.ts
+++ b/client/src/types/type.ts
@@ -8,8 +8,8 @@ export interface PostState {
 }
 
 export interface Category {
-  id: number | null;
-  name: string;
+  category_id: number | null;
+  category_name: string;
   isActive?: boolean;
 }
 


### PR DESCRIPTION
<!--
  제목은 `제목 : (FE, BE) [(키워드)] (작업 내용)` 로 작성해 주세요
  키워드 예시: FEAT, FIX, STYLE, CHORE ... 등
-->

### 스크린샷 
![image](https://github.com/user-attachments/assets/f147f0f6-7f99-44e3-99d9-efe5187f90f6)

<!--
  (Optional)
  UI가 변경되었다면 사진이나 Gif를 추가해 주세요.
-->
![image](https://github.com/user-attachments/assets/6e36cefa-1954-4d94-803a-f49151715fb3)

### 작업 내용

<!-- PR 본문을 입력하세요. -->
메인페이지에서 '게시글 아이콘' 누르면 카테고리 목록으로 먼저 이동하도록 라우터 수정하였습니다. 

카테고리 클릭하면 해당 카테고리에 있는 글 목록이 출력됩니다. 

스타일 적용은 하지 않고 우선 서버 데이터 받아오는 것만 구현하였습니다. 
